### PR TITLE
Improve YAML output

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -130,7 +130,8 @@ python3 generate-benchmark.py \
   --prefix-definitions "$(cat prefixes/DATASET.ttl)" \
   --kg-name DATASET \
   --external-url http://localhost:FREEPORT \
-  --port FREEPORT
+  --port FREEPORT \
+  --output-format tsv
 ```
 
 If you would like to run the SPARQL engine on `HOST_A` and the `generate-benchmark.py` program on `HOST_B`, please set `--sparql-endpoint http://HOST_A:PORT` and `--external-url http://HOST_B:FREEPORT` and ensure that both machines can access the respective ports through their firewalls.
@@ -145,7 +146,8 @@ python3 generate-benchmark.py \
   --prefix-definitions "$(cat prefixes/dblp.ttl)" \
   --kg-name dblp \
   --external-url http://localhost:8080 \
-  --port 8080
+  --port 8080 \
+  --output-format tsv
 ```
 
 ### 3.3. Stop QLever

--- a/util/benchmark_tsv2yaml.py
+++ b/util/benchmark_tsv2yaml.py
@@ -1,0 +1,53 @@
+import yaml
+import argparse
+import re
+
+QUERY_NAME = re.compile(r'^(?P<name>.+) \[(?P<description>.+)\]$')
+
+
+class MultiLineDumper(yaml.SafeDumper):
+    "Custom dumper for YAML, that dumps all values of key `query` using `|-`."
+
+    def represent_scalar(self, tag, value, style=None):
+        value = value.replace("\r\n", "\n")
+        if isinstance(value, str) and "\n" in value:
+            style = "|"
+        return super().represent_scalar(tag, value, style)
+
+
+def command_line_args() -> argparse.Namespace:
+    """
+    Parse the command line arguments and return them
+    """
+    arg_parser = argparse.ArgumentParser(
+        description="This helper converts a TSV benchmark file to YAML.")
+    arg_parser.add_argument("tsv_file", type=str, help="The source TSV file.")
+    arg_parser.add_argument("--kg-title", "-t", type=str, required=True)
+    arg_parser.add_argument("--kg-description", "-d", type=str)
+    return arg_parser.parse_args()
+
+
+def convert(tsv: str, title: str, description: str) -> str:
+    lines = tsv.splitlines(keepends=False)
+    yaml_dict = {
+        "title": title,
+        "description": description,
+        "queries": [],
+    }
+    for line in lines:
+        name, query = line.split("\t")
+        m = QUERY_NAME.match(name)
+        assert m
+        yaml_dict["queries"].append({
+            "name": m.group("name"),
+            "description": m.group("description"),
+            "query": query,
+        })
+    return yaml.dump(yaml_dict, sort_keys=False, Dumper=MultiLineDumper)
+
+
+if __name__ == "__main__":
+    args = command_line_args()
+    with open(args.tsv_file) as f:
+        tsv = f.read()
+    print(convert(tsv, args.kg_title, args.kg_description))


### PR DESCRIPTION
- YAML output now has an improved structure (see below)
- YAML now is the default output format (TSV can still be used via `--output-format tsv`)
- This also adds a converter from the TSV to YAML structure `benchmark_tsv2yaml.py` (however this does not pretty print the queries - they remain one-liners)
- Implements suggestions from and closes #13

New output format:

```yaml
title: DBLP
description: Computer Science Bibliography from DBLP, ca. 500 M triples
queries:
- name: join-2-small-large
  description: JOIN of a small and a large predicate
  query: |-
    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
    PREFIX dblp: <https://dblp.org/rdf/schema#>
    SELECT (COUNT(*) AS ?count) WHERE {
      ?s dblp:formerStreamTitle ?o1 .
      ?s rdf:type ?o2
    }
...
```